### PR TITLE
feat(1936): Add parse into to env vars

### DIFF
--- a/lib/circuit-breaker.js
+++ b/lib/circuit-breaker.js
@@ -15,9 +15,9 @@ const CircuitBreaker = function (func, options) {
 
     this.options = options || {};
     this.func = func;
-    this.timeout = this.options.timeout || 10000; // default 10 second timeout (ms)
-    this.resetTimeout = this.options.resetTimeout || 60000; // default 1 minute reset timeout (ms)
-    this.maxFailures = this.options.maxFailures || 5; // default max number of failures to open circuit
+    this.timeout = this.options.timeout || process.env.BREAKER_TIMEOUT || 20000; // default 20 second timeout (ms)
+    this.resetTimeout = this.options.resetTimeout || process.env.BREAKER_RESET_TIMEOUT || 5000; // default 5 seconds reset timeout (ms)
+    this.maxFailures = this.options.maxFailures || process.env.BREAKER_MAX_FAILURES || 10; // default max number of failures to open circuit
     this.errorFn = this.options.errorFn || function () { return true; }; // optional function to break based on custom conditions for error object
 
     // Initially circuit is always closed

--- a/lib/circuit-breaker.js
+++ b/lib/circuit-breaker.js
@@ -15,9 +15,12 @@ const CircuitBreaker = function (func, options) {
 
     this.options = options || {};
     this.func = func;
-    this.timeout = this.options.timeout || parseInt(process.env.BREAKER_TIMEOUT, 10) || 20000; // default 20 second timeout (ms)
-    this.resetTimeout = this.options.resetTimeout || parseInt(process.env.BREAKER_RESET_TIMEOUT, 10) || 5000; // default 5 seconds reset timeout (ms)
-    this.maxFailures = this.options.maxFailures || parseInt(process.env.BREAKER_MAX_FAILURES, 10) || 10; // default max number of failures to open circuit
+    this.timeout = this.options.timeout
+        || parseInt(process.env.BREAKER_TIMEOUT, 10) || 20000; // default 20 second timeout (ms)
+    this.resetTimeout = this.options.resetTimeout ||
+        parseInt(process.env.BREAKER_RESET_TIMEOUT, 10) || 5000; // default 5 seconds reset timeout (ms)
+    this.maxFailures = this.options.maxFailures
+        || parseInt(process.env.BREAKER_MAX_FAILURES, 10) || 10; // default max number of failures to open circuit
     this.errorFn = this.options.errorFn || function () { return true; }; // optional function to break based on custom conditions for error object
 
     // Initially circuit is always closed

--- a/lib/circuit-breaker.js
+++ b/lib/circuit-breaker.js
@@ -15,9 +15,9 @@ const CircuitBreaker = function (func, options) {
 
     this.options = options || {};
     this.func = func;
-    this.timeout = this.options.timeout || process.env.BREAKER_TIMEOUT || 20000; // default 20 second timeout (ms)
-    this.resetTimeout = this.options.resetTimeout || process.env.BREAKER_RESET_TIMEOUT || 5000; // default 5 seconds reset timeout (ms)
-    this.maxFailures = this.options.maxFailures || process.env.BREAKER_MAX_FAILURES || 10; // default max number of failures to open circuit
+    this.timeout = this.options.timeout || parseInt(process.env.BREAKER_TIMEOUT, 10) || 20000; // default 20 second timeout (ms)
+    this.resetTimeout = this.options.resetTimeout || parseInt(process.env.BREAKER_RESET_TIMEOUT, 10) || 5000; // default 5 seconds reset timeout (ms)
+    this.maxFailures = this.options.maxFailures || parseInt(process.env.BREAKER_MAX_FAILURES, 10) || 10; // default max number of failures to open circuit
     this.errorFn = this.options.errorFn || function () { return true; }; // optional function to break based on custom conditions for error object
 
     // Initially circuit is always closed

--- a/test/circuitbreaker.test.js
+++ b/test/circuitbreaker.test.js
@@ -225,7 +225,7 @@ describe('Circuit Breaker', () => {
 
             callback.yields(new Error('fail'));
 
-            const noop = function () {};
+            const noop = function () { };
 
             breaker.invoke('fail').fail(noop);
             breaker.invoke('fail').fail(noop);
@@ -260,7 +260,7 @@ describe('Circuit Breaker', () => {
 
             breaker.on('rejected', () => done());
 
-            breaker.invoke('pass').fail(() => {});
+            breaker.invoke('pass').fail(() => { });
         });
 
         it('should invoke function once and then fail fast when in half-open state', (done) => {
@@ -327,7 +327,7 @@ describe('Circuit Breaker', () => {
                 maxFailures: 3,
                 resetTimeout: 3000
             });
-            const noop = function () {};
+            const noop = function () { };
 
             breaker.invoke().fail(noop);
             breaker.invoke().fail(noop);
@@ -363,7 +363,22 @@ describe('Circuit Breaker', () => {
 
             breaker.on('timeout', () => done());
 
-            breaker.invoke().fail(() => {});
+            breaker.invoke().fail(() => { });
+        });
+
+        it('should take timeout value from env variable', (done) => {
+            const timeout = function (cb) {
+                setTimeout(cb, 20);
+            };
+
+            process.env.BREAKER_TIMEOUT = 10;
+            process.env.BREAKER_RESET_TIMEOUT = 6000;
+            process.env.BREAKER_MAX_FAILURES = 5;
+            const breaker = new CircuitBreaker(timeout, {});
+
+            breaker.on('timeout', () => done());
+
+            breaker.invoke().fail(() => { });
         });
     });
 
@@ -389,7 +404,7 @@ describe('Circuit Breaker', () => {
                     return true;
                 }
             });
-            const noop = function () {};
+            const noop = function () { };
 
             breaker.invoke(-1).fail(noop);
             breaker.invoke(-2).fail(noop);
@@ -416,7 +431,7 @@ describe('Circuit Breaker', () => {
                 maxFailures: 3,
                 resetTimeout: 30
             });
-            const noop = function () {};
+            const noop = function () { };
 
             breaker.invoke(-1).fail(noop);
             breaker.invoke(-2).fail(noop);


### PR DESCRIPTION
## Context

circuit-breaker default settings are not optimized and can result in genuine requests being blocked and can cause build failures.

## Objective

This PR adds parseint to the env variables for breaker timeout

## References

https://github.com/screwdriver-cd/screwdriver/issues/1936

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.